### PR TITLE
Text clarification

### DIFF
--- a/HonorAmongThieves/Pages/Cakery.cshtml
+++ b/HonorAmongThieves/Pages/Cakery.cshtml
@@ -37,9 +37,9 @@
                 <br />
                 <div class="display-4">
                     <u>GAME PARAMETERS</u><br />
-                    Starting Cash: <input type="number" step="1" min="0" max="9999999" value="1200" id="startingcash" /><br />
-                    Annual Allowance: <input type="number" step="1" min="0" max="9999999" value="200" id="annualallowance" /><br />
-                    Upgrade Credit: <input type="number" step="1" min="0" max="9999999" value="10000" id="upgradeallowance" /><br />
+                    Starting $$: <input type="number" step="1" min="0" max="9999999" value="1200" id="startingcash" /><br />
+                    Annual $$: <input type="number" step="1" min="0" max="9999999" value="200" id="annualallowance" /><br />
+                    Upgrade $$: <input type="number" step="1" min="0" max="9999999" value="10000" id="upgradeallowance" /><br />
                     Game Length: <input type="number" step="1" min="2" max="999" value="6" id="gamelength" /><br />
                 </div>
             </div>

--- a/HonorAmongThieves/Pages/Cakery.cshtml
+++ b/HonorAmongThieves/Pages/Cakery.cshtml
@@ -38,7 +38,7 @@
                 <div class="display-4">
                     <u>GAME PARAMETERS</u><br />
                     Starting $$: <input type="number" step="1" min="0" max="9999999" value="1200" id="startingcash" /><br />
-                    Annual $$: <input type="number" step="1" min="0" max="9999999" value="200" id="annualallowance" /><br />
+                    Allowance $$: <input type="number" step="1" min="0" max="9999999" value="200" id="annualallowance" /><br />
                     Upgrade $$: <input type="number" step="1" min="0" max="9999999" value="10000" id="upgradeallowance" /><br />
                     Game Length: <input type="number" step="1" min="2" max="999" value="6" id="gamelength" /><br />
                 </div>

--- a/HonorAmongThieves/Pages/Cakery.cshtml
+++ b/HonorAmongThieves/Pages/Cakery.cshtml
@@ -38,8 +38,8 @@
                 <div class="display-4">
                     <u>GAME PARAMETERS</u><br />
                     Starting Cash: <input type="number" step="1" min="0" max="9999999" value="1200" id="startingcash" /><br />
-                    Allowance: <input type="number" step="1" min="0" max="9999999" value="200" id="annualallowance" /><br />
-                    Upgrade Allowance: <input type="number" step="1" min="0" max="9999999" value="10000" id="upgradeallowance" /><br />
+                    Annual Allowance: <input type="number" step="1" min="0" max="9999999" value="200" id="annualallowance" /><br />
+                    Upgrade Credit: <input type="number" step="1" min="0" max="9999999" value="10000" id="upgradeallowance" /><br />
                     Game Length: <input type="number" step="1" min="2" max="999" value="6" id="gamelength" /><br />
                 </div>
             </div>

--- a/HonorAmongThieves/wwwroot/CakeryInstructions.html
+++ b/HonorAmongThieves/wwwroot/CakeryInstructions.html
@@ -35,7 +35,7 @@
         <hr />
         <h3>SETUP</h3>
         Each player starts with an 'Upgrade Credit'. This is an amount of money that can only be used for upgrading. <br />
-        Each player gets an 'Annual Allowance' at the start of every year. <br />
+        Each player gets an 'Allowance' at the start of every round. <br />
         <hr />
         <a href="/">back</a>
     </div>

--- a/HonorAmongThieves/wwwroot/js/cakery.js
+++ b/HonorAmongThieves/wwwroot/js/cakery.js
@@ -228,7 +228,7 @@ connection.on("UpdateProductionState", function (currentPrices, currentMarket, p
 
 // Display the common buttons and tables for baking menu
 function showCommonMenuButtons() {
-    document.getElementById("currentyear").textContent = "YEAR: " + (gameState.currentMarket.currentYear + 1) + "/" + gameState.currentMarket.maxYears;
+    document.getElementById("currentyear").textContent = "ROUND: " + (gameState.currentMarket.currentYear + 1) + "/" + gameState.currentMarket.maxYears;
 
     var elements = document.getElementsByClassName("commonmenubutton");
     for (var i = 0; i < elements.length; i++) {
@@ -881,7 +881,7 @@ function showUseUpgradeMenu() {
 
         var buyupgradetousemessage = document.createElement("TD");
         buyupgradetousemessage.colSpan = 5;
-        buyupgradetousemessage.appendChild(document.createTextNode("You don't have any usable upgrades. Buy some above. Upgrades only come into play the year after they are purchased."));
+        buyupgradetousemessage.appendChild(document.createTextNode("You don't have any usable upgrades. Buy some above. Upgrades only come into play the round after they are purchased."));
         tr.appendChild(buyupgradetousemessage);
         useUpgradeTable.appendChild(tr);
     }
@@ -968,7 +968,7 @@ function summarizeGoodsBaked() {
     }
 
     changeUiState("SET UP SHOP", "goodsbaked");
-    document.getElementById("currentyearsummary").textContent = "YEAR: " + (gameState.currentMarket.currentYear + 1) + "/" + gameState.currentMarket.maxYears;
+    document.getElementById("currentyearsummary").textContent = "ROUND: " + (gameState.currentMarket.currentYear + 1) + "/" + gameState.currentMarket.maxYears;
 
     document.getElementById("cookiesbeingsold").textContent = playerState.bakedGoods.cookies;
     document.getElementById("croissantsbeingsold").textContent = playerState.bakedGoods.croissants;
@@ -1095,7 +1095,7 @@ connection.on("ShowMarketReport", function (marketReport, currentPlayerSales, go
         marketReportTable.appendChild(tr);
     }
 
-    document.getElementById("marketreporttitle").textContent = "YEAR: " + gameState.currentMarket.currentYear + "/"
+    document.getElementById("marketreporttitle").textContent = "ROUND: " + gameState.currentMarket.currentYear + "/"
         + gameState.currentMarket.maxYears + " SALES REPORT";
 
     if (currentPlayerSales.item1 > 0) {

--- a/HonorAmongThieves/wwwroot/js/cakery.js
+++ b/HonorAmongThieves/wwwroot/js/cakery.js
@@ -961,7 +961,7 @@ function updateUpgradeUse(upgrade, useCost, useEffect) {
 // -------------------------
 function summarizeGoodsBaked() {
     if (playerState.resources.upgradeAllowance > 0) {
-        document.getElementById("upgradecreditwarning").textContent = "Note: You have ended your turn with $" + (playerState.resources.upgradeAllowance / 100).toFixed(2) + " of unspent Upgrade Credit! Buy upgrades early to use them more.";
+        document.getElementById("upgradecreditwarning").textContent = "Note: You have ended your turn with $" + (playerState.resources.upgradeAllowance / 100).toFixed(2) + " of unspent Upgrade Credit.";
     }
     else {
         document.getElementById("upgradecreditwarning").style.display = "none";

--- a/HonorAmongThieves/wwwroot/js/cakery.js
+++ b/HonorAmongThieves/wwwroot/js/cakery.js
@@ -961,7 +961,7 @@ function updateUpgradeUse(upgrade, useCost, useEffect) {
 // -------------------------
 function summarizeGoodsBaked() {
     if (playerState.resources.upgradeAllowance > 0) {
-        document.getElementById("upgradecreditwarning").textContent = "YOU STILL HAVE $" + (playerState.resources.upgradeAllowance / 100).toFixed(2) + " OF UPGRADE CREDIT LEFT TO SPEND!";
+        document.getElementById("upgradecreditwarning").textContent = "Note: You have ended your turn with $" + (playerState.resources.upgradeAllowance / 100).toFixed(2) + " of unspent Upgrade Credit! Buy upgrades early to use them more.";
     }
     else {
         document.getElementById("upgradecreditwarning").style.display = "none";


### PR DESCRIPTION
- Clarify "upgrade credit unspent" warning to indicate clearly that the round is already over
- Shorten startup columns
- Change 'year' to 'round' in UI